### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  # - name: GitHub Community Support
+  #   url: https://github.com/orgs/community/discussions
+  #   about: Please ask and answer questions here.
+  - name: GitHub Security Bug Bounty
+    url: https://bounty.github.com/
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,52 @@
+
+---
+name: 🌟 General Feedback
+about: Share feedback, report usability issues, or suggest improvements.
+title: "[Feedback]: "
+labels: ["feedback"]
+assignees: []
+---
+
+Thanks for helping us improve! Please fill out whatever you can.
+
+### Page URL
+(e.g., https://your-site/page)
+
+### What happened?
+Describe the issue or feedback in a sentence or two.
+
+### Steps (optional)
+If applicable, list how you encountered this:
+1.
+2.
+3.
+
+### Expected vs Actual (optional)
+**Expected:**  
+**Actual:**
+
+### Impact / Severity
+- [ ] Low (minor inconvenience)
+- [ ] Medium (affects normal use)
+- [ ] High (blocks or severely impairs use)
+
+### Type of feedback (check any)
+- [ ] Usability / UX
+- [ ] Design / Layout
+- [ ] Content / Copy
+- [ ] Performance / Speed
+- [ ] Accessibility
+- [ ] Bug
+- [ ] Other
+
+### Environment (optional)
+**Browser:** (e.g., Chrome 120, Safari 17)  
+**Device & OS:** (e.g., macOS 14, iPhone 14 iOS 18)
+
+### Screenshots or notes (optional)
+(Drag-and-drop images here)
+
+### Contact (optional)
+Email or GitHub username if you’d like us to follow up.
+
+> I understand this feedback will be public in this repository.

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -3,14 +3,15 @@
 name: 🌟 General Feedback
 about: Share feedback, report usability issues, or suggest improvements.
 title: "[Feedback]: "
-labels: ["feedback"]
+labels: ["feedback", "website", "public"]
 assignees: []
 ---
 
 Thanks for helping us improve! Please fill out whatever you can.
 
 ### Page URL
-(e.g., https://your-site/page)
+
+https://orca.research.sfu.ca/call-library
 
 ### What happened?
 Describe the issue or feedback in a sentence or two.

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,123 @@
+
+name: 🌟 General Feedback
+description: Share feedback, report usability issues, or suggest improvements.
+title: "[Feedback]: "
+labels:
+  - feedback
+  - public
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to help us improve! Please provide as much detail as you can.
+        _Tip: If you came from the website’s “Report an Issue” button, the page URL may already be filled in._
+
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      description: Paste the exact page where you experienced the issue (e.g., https://example.com/path).
+      placeholder: https://orca.research.sfu.ca/call-library
+    validations:
+      required: true
+
+  - type: textarea
+    id: how_happened
+    attributes:
+      label: Page options?
+      description: Describe the selected page / dropdown options
+      placeholder: e.g., Population, clan, search.
+    validations:
+      required: false
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: Briefly describe the problem or feedback.
+      placeholder: e.g., The search felt slow; the sidebar overlaps content on mobile; confusing wording on the homepage.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps (optional)
+      description: If it’s a usability or bug issue, list the steps you took.
+      placeholder: |
+        1. Went to ...
+        2. Clicked ...
+        3. Expected ...
+        4. Saw ...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Impact / Severity
+      description: How much does this affect your experience?
+      options:
+        - Low (minor inconvenience)
+        - Medium (affects normal use)
+        - High (blocks or severely impairs use)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: type
+    attributes:
+      label: Type of feedback
+      options:
+        - label: Usability / UX
+        - label: Design / Layout
+        - label: Content / Copy
+        - label: Performance / Speed
+        - label: Accessibility
+        - label: Bug
+        - label: Other
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Example: Chrome 120, Firefox 122, Safari 17
+      placeholder: Chrome 120
+    validations:
+      required: false
+
+  - type: input
+    id: device
+    attributes:
+      label: Device & OS
+      description: Example: Windows 11, macOS 14, iPhone 14 (iOS 18), Pixel 6 (Android 14)
+      placeholder: macOS 14 (Safari)
+    validations:
+      required: false
+
+  - type: textarea
+    id: attachments
+    attributes:
+      label: Screenshots or notes (optional)
+      description: Drag-and-drop images, or paste links for context.
+    validations:
+      required: false
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact (optional)
+      description: If you’d like us to follow up, leave an email or GitHub username.
+      placeholder: your@email.com
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Consent
+      description: Please confirm you understand how we use feedback.
+      options:
+        - label: I understand this feedback will be public in this repository.
+          required: true


### PR DESCRIPTION
Enable templates for GitHub Issues. Includes templates for _bug report_, _feature request_ and a _feedback_ (for website users)